### PR TITLE
0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ By default, nobody cared about piracy, you could hijack 1000 ships in front of t
 Now, piracy is a crime, and if you do it enough, people will consider you a criminal.
 
 ### Removed boarding pods orbiting ship when using marines to claim a ship
-When using marines to claim a ship, they will no longer endlessly orbit it.
+When using marines to claim a ship, they will use the "Travel drive" to get closer and they will no longer endlessly orbit it.
 
 ### Removed extra damage done when claiming with marines
 Your marines have been instructed to be as careful as you are when claiming ships, so they will no longer cause any extra damage to the ships they claim.
@@ -51,6 +51,9 @@ Added more than 20 configuration options to let you tune the mod to your likings
  - https://text2voice.org, https://twistedwave.com/online and https://voicechanger.io/ -> All of them used to create the custom dialog lines.
 
 ## Changelog
+### 0.8.0
+ - When using marines to claim a ship, the boarding pod will use the travel drive
+ - Improved logic to avoid having boarding pods orbiting ship when using marines to claim a ship
 ### 0.7.0
  - Removed boarding pods orbiting ship when using marines to claim a ship
  - Added German translation

--- a/aiscripts/move.claim.xml
+++ b/aiscripts/move.claim.xml
@@ -6,19 +6,28 @@
 	<remove sel="/aiscript/attention[@min='visible']/actions/do_if[5]/do_if[1]"/>
 
 	<!-- Avoid having marines looping arround the target -->
-	<!-- This selector matches lines 59 -->
-	<replace sel="//move_to[@flightbehaviour='flightbehaviour.droneattach']">
+	<!-- This selector matches lines 31 -->
+	<replace sel="//move_to[@flightbehaviour='flightbehaviour.default']">
 		<move_to
 			destination="$target"
 			object="this.ship"
 			uselocalhighways="false"
-			forcesteering="true"
+			forcesteering="false"
+			finishonapproach="false"
+			travel="true"
+			flightbehaviour="flightbehaviour.generic"
 		>
 			<interrupt>
 				<conditions>
-					<event_object_approaching_waypoint object="this.ship"/>
+					<event_object_collided object="this.ship" otherobject="$target"/>
 				</conditions>
 			</interrupt>
 		</move_to>
+		<stop_moving object="this.ship"/>
+		<resume label="better_piracy_skip"/>
 	</replace>
+	<!-- This selector matches lines 66 -->
+	<add sel="//attach_object_to_target" pos="before">
+		<label name="better_piracy_skip"/>
+	</add>
 </diff>

--- a/assets/props/Engines/macros/engine_arg_xs_pv_01_macro.xml
+++ b/assets/props/Engines/macros/engine_arg_xs_pv_01_macro.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<diff>
+  <add sel="//properties">
+    <travel charge="1" thrust="18" attack="45" release="30" />
+  </add>
+</diff>

--- a/content.xml
+++ b/content.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<content id="ws_2056100433" name="Better piracy" description="X4 Foundations mod to improve piracy." version="700" save="0" author="alberto-rota" date="2020-04-27" sync="false" lastupdate="1588010098">
+<content id="ws_2056100433" name="Better piracy" description="X4 Foundations mod to improve piracy." version="800" save="0" author="alberto-rota" date="2020-04-29" sync="false" lastupdate="1588187607">
   <langugage language="7" description="X4 Foundations mod to improve piracy."/>
   <langugage language="33" description="X4 Foundations mod to improve piracy."/>
   <langugage language="34" description="Mod para X4 Foundations que mejora la piratería."/>


### PR DESCRIPTION
 - When using marines to claim a ship, the boarding pod will use the travel drive
 - Improved logic to avoid having boarding pods orbiting ship when using marines to claim a ship
 - Uploaded to Steam