### PR TITLE
0.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ _X4 Foundations mod to improve piracy_
 
 ## Compatibility
 Compatible with `3.x`, with and without `Split vendetta`.
+
 Savegame friendly. (Both adding and removal)
 
 ## Description
@@ -10,21 +11,31 @@ This mod addresses several piracy gameplay-aspects in X4 that I really dislike.
 
 If you want to force some S/M ship to bail or soften an L/XL ship before boarding, right-click it, choose "Harass" and follow the instructions.
 
-Also, you can configure it as much as you want usin the in-game menu.
+Also, you can configure it as much as you want using the in-game menu.
 
-## Detailed changes explanation
+## Major changes explanation
 
-### Replaced "Surrender!" dialog option by "Harass" contextual action.
-Replaced the confusing and mostly random "Surrender!" dialog option by a more streamlined "Harass" contextual menu action.
+### Replaced `Surrender!` dialog option by `Harass` contextual action.
+Replaced the confusing and mostly random `Surrender!` dialog option by a more streamlined `Harass` contextual menu action.
 
-If you want to force some S/M ship to bail, or soften an L/XL ship before boarding, right-click it and choose "Harass".
+If you want to force some S/M ship to bail, or soften an L/XL ship before boarding, right-click it and choose `Harass`.
 
-That will start a quest, follow the steps and the prize will be yours.
+That will start a mission, follow the steps and the prize will be yours.
 
 ### Create your own pirate gang.
 Subordinates of the ship you are piloting will smartly participate in the "Harass operation", helping you while avoiding killing the target.
 
 Tip: Use ships with a lot of shields and prefer high-shield/low-hull damage weapons for maximum effectiveness.
+
+### Create your own pirate imperium.
+You will be able to instruct your most experienced pilots (3 stars or more) to do harass operations on their own, just assemble a small fleet and assing the `Corsair` default order to their leader.
+
+Tip: The _Argon trading station_ in _Hatikvah's Choice I_ is usually full of HOP and ZIA traders (ARG/HAT will not protect nor care about them), that's a good spot to start.
+
+### Added a lot of config options to let you tune the piracy
+Added more than 20 configuration options to let you tune the mod to your likings.
+
+## Minor changes explanation
 
 ### Removed "Ship type penalty" from the bailing calculation
 Before, you were heavily punished if you were flying a ship with a higher `maxHull` than the enemy you were harassing.
@@ -45,17 +56,24 @@ When using marines to claim a ship, they will use the "Travel drive" to get clos
 ### Removed extra damage done when claiming with marines
 Your marines have been instructed to be as careful as you are when claiming ships, so they will no longer cause any extra damage to the ships they claim.
 
-### Added a lot of config options to let you tune the piracy
-Added more than 20 configuration options to let you tune the mod to your likings.
+### Stations will not allow a fleeing ship to dock if the attacker is allied to them
+Your allies will no longer protect your enemies from you!
 
 ## Credits
  - vx -> Author of `True Capture`, where a lot of inspiration was drawn.
  - Kevrlet -> Author of `FixBailChance`, where a lot of inspiration was drawn.
  - SirNukes -> Author of `SirNukes Mod Support APIs`.
  - Smashicons -> Author of the image used as Thumbnail (https://www.flaticon.es/autores/smashicons)
- - https://text2voice.org, https://twistedwave.com/online and https://voicechanger.io/ -> All of them used to create the custom dialog lines.
+ - https://text2voice.org, https://twistedwave.com/online, and https://voicechanger.io/ -> All of them used to create the custom dialog lines.
 
 ## Changelog
+### 0.11.0
+ - Created new default order `Corsair`, ships/fleets with this behavior will smartly harass selected enemy targets
+ - Improved Harass operation logic
+ - Improved debug logging
+ - Disabled `combat_reputation_hit` and `harass_reputation_hit`, I need to find a better way of handling it
+ - Stations will not allow a fleeing ship to dock if the attacker is allied to them
+ - Separated changes into `Major changes` and `Minor changes` to increase readability
 ### 0.10.0
  - Subordinates of the player ship will smartly participate in the "Harass operation"
 ### 0.9.0
@@ -71,14 +89,14 @@ Added more than 20 configuration options to let you tune the mod to your likings
  - Added custom dialog lines during harass operation, now you know that you are threatening them.
  - Minor fixes
 ### 0.5.0
- - Improved the "Harass" command vs capital ships, now it will only shoften them.
- - Added distance checks to the "Harass" command, now you really need to stick on the target.
+ - Improved the `Harass` command vs capital ships, now it will only soften them.
+ - Added distance checks to the `Harass` command, now you really need to stick on the target.
  - Added a lot of config options.
 ### 0.4.0
- - Reworked all the "RightClick -> Harass" code, not should work much better.
+ - Reworked all the `RightClick -> Harass` code, not should work much better.
  - Externalized hard-coded texts to I18N files (English and Spanish).
 ### 0.3.0
- - Removed "Surrender!" dialog, replaced it by a more streamlined "RightClick -> Harass".
+ - Removed `Surrender!` dialog, replaced it by a more streamlined `RightClick -> Harass`.
  - Added dependency to "SirNukes Mod Support APIs"
 ### 0.2.0
  - Forcing a pilot to bail out of their ship will negatively impact your relations with his/her faction.

--- a/aiscripts/betterpiracy.order.fight.corsair.xml
+++ b/aiscripts/betterpiracy.order.fight.corsair.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<aiscript name="betterpiracy.order.fight.corsair" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://x4libonline.ddns.net/libraries/aiscripts.xsd">
+	<order id="Corsair" name="{61537, 5052}" description="{61537, 5053}" category="combat" infinite="true">
+		<params>
+			<param name="destination" type="position" text="{1041, 10007}" comment="Area to patrol">
+				<input_param name="class" value="class.sector" />
+			</param>
+			<param name="radius" type="length" default="this.ship.maxradarrange" text="{1041, 10093}" comment="Radius">
+				<input_param name="min" value="1km" />
+				<input_param name="max" value="[this.ship.maxradarrange, 1km].max" />
+				<input_param name="step" value="1km" />
+			</param>
+
+			<param name="harass_s_ships" default="false" type="bool" text="{61537, 5054}" /> <!-- class.ship_s -->
+			<param name="harass_m_ships" default="true" type="bool" text="{61537, 5055}" /> <!-- class.ship_m -->
+
+			<param name="harass_combat_ships" default="false" type="bool" text="{61537, 5056}" /> <!-- purpose.fight -->
+			<param name="harass_trader_ships" default="true" type="bool" text="{61537, 5057}" /> <!-- purpose.trade -->
+			<param name="harass_miner_ships" default="true" type="bool" text="{61537, 5058}" /> <!-- purpose.mine -->
+		</params>
+		<skill min="60"/>
+		<requires>
+			<match shiptype="shiptype.lasertower" negate="true" />
+		</requires>
+		<location object="$destination.{1}" position="$destination.{2}" radius="$radius" />
+	</order>
+	<interrupts>
+		<handler ref="SectorChangeHandler" />
+		<handler ref="ScannedHandler" />
+		<handler ref="InspectedHandler" />
+		<handler ref="FoundAbandonedHandler" />
+		<handler ref="FoundLockboxHandler" />
+		<handler ref="TargetInvalidHandler" />
+		<handler ref="ResupplyHandler" />
+	</interrupts>
+	<init>
+		<set_command command="command.patrol" />
+		<do_if value="$destination.{1}.isclass.sector">
+			<set_value name="$targetsector" exact="$destination.{1}" />
+		</do_if>
+		<do_elseif value="$destination.{1}.isclass.zone">
+			<do_if value="$destination.{1}.isclass.highway">
+				<debug_to_file name="'BetterPiracy'" text="'%1 (%2) was sent to harass an area inside a highway. This is not supported.  Destination Space: %3 (%4), Position: %5'.[this.ship.knownname, this.ship, $destination.{1}.knownname, $destination.{1}, $destination.{2}]" />
+				<return />
+			</do_if>
+			<do_elseif value="$destination.{1}.sector">
+				<set_value name="$targetsector" exact="$destination.{1}.sector" />
+				<create_position name="$position" space="$targetsector" value="$destination.{2}" object="$destination.{1}" />
+			</do_elseif>
+			<do_else>
+				<debug_to_file name="'BetterPiracy'" text="'This situation where a zone is not in a sector is unaccounted for. Destination Space: %1 (%2), Position: %3'.[$destination.{1}.knownname, $destination.{1}, $destination.{2}]" />
+				<return />
+			</do_else>
+		</do_elseif>
+		<do_else>
+			<debug_to_file name="'BetterPiracy'" text="'Input destination is not in a valid space. Destination Space: %1 (%2), Position: %3'.[$destination.{1}.knownname, $destination.{1}, $destination.{2}]" />
+			<return />
+		</do_else>
+		<do_if value="not $position?">
+			<set_value name="$position" exact="$destination.{2}" />
+		</do_if>
+
+		<debug_to_file name="'BetterPiracy'" text="'%s --- betterpiracy.order.fight.corsair --- %s (%s) initialized Corsair: $destination = %s, $radius = %s, $harass_s_ships = %s, $harass_m_ships = %s, $harass_combat_ships = %s, $harass_trader_ships = %s, $harass_miner_ships = %s.'.[player.age, this.assignedcontrolled.knownname, this.assignedcontrolled.idcode, $destination, $radius, $harass_s_ships, $harass_m_ships, $harass_combat_ships, $harass_trader_ships, $harass_miner_ships]" />
+	</init>
+	<attention min="unknown">
+		<actions>
+			<!-- Initial checks -->
+			<label name="start" />
+
+			<!-- If we are in a different zone, move to the target zone -->
+			<do_if value="(this.sector != $targetsector) or (this.ship.distanceto.[$targetsector, $position] gt $radius)">
+				<debug_to_file name="'BetterPiracy'" text="'%s --- betterpiracy.order.fight.corsair --- %s (%s) moving to target zone.'.[player.age, this.assignedcontrolled.knownname, this.assignedcontrolled.idcode]" />
+				<run_script name="'move.generic'">
+					<param name="destination" value="$targetsector" />
+					<param name="position" value="$position" />
+					<param name="endintargetzone" value="true" />
+					<param name="activepatrol" value="true" />
+					<param name="radius" value="$radius" />
+					<param name="radiusanchorpos" value="$position" />
+					<param name="radiusanchorspace" value="$targetsector" />
+				</run_script>
+			</do_if>
+
+			<!-- Obtain the $targetzone -->
+			<get_zone_at_position name="$targetzone" sector="$targetsector" value="$position" />
+			<do_if value="not $targetzone">
+				<!-- If there is still no zone at the position, the position is unobstructed and we are fairly close. Move straight there. -->
+				<move_to object="this.ship" destination="$targetsector" uselocalhighways="false" finishonapproach="true">
+					<position value="$position" />
+				</move_to>
+				<!-- At this point, we should be at the destination, so there should now be a zone. -->
+				<get_zone_at_position name="$targetzone" sector="$targetsector" value="$position" />
+				<do_if value="not $targetzone">
+					<debug_to_file name="'BetterPiracy'" text="'Error: %1 (%2) should be at the destination zone, but there still is no zone at the destination. present location: %3, %4, %5. destination: %6'.[this.ship.knownname, this.ship, this.ship.zone.knownname, this.ship.sector.knownname, this.ship.cluster.knownname, $destination]" />
+					<return />
+				</do_if>
+			</do_if>
+
+			<!-- Translate sector coordinates to zone coordinates. -->
+			<do_if value="$targetzone">
+				<!-- Input: $position relative to $targetsector. Output: $zoneposition relative to $targetzone. -->
+				<create_position name="$zoneposition" space="$targetzone" value="$position" object="$targetsector" />
+				<debug_to_file name="'BetterPiracy'" text="'%1 (%2) destination coordinates are now: %3 in %4 (%5), %6, %7'.[this.ship.knownname, this.ship, $zoneposition, $targetzone.knownname, $targetzone.macro, $targetzone.sector.knownname, $targetzone.cluster.knownname]" />
+			</do_if>
+
+			<!-- Generate target filters - targetclasses -->
+			<set_value name="$targetclasses" exact="[]" />
+			<do_if value="$harass_s_ships">
+				<append_to_list name="$targetclasses" exact="class.ship_s" />
+			</do_if>
+			<do_if value="$harass_m_ships">
+				<append_to_list name="$targetclasses" exact="class.ship_m" />
+			</do_if>
+
+			<!-- Generate target filters - targetpurposes -->
+			<set_value name="$targetpurposes" exact="[]" />
+			<do_if value="$harass_combat_ships">
+				<append_to_list name="$targetpurposes" exact="purpose.fight" />
+			</do_if>
+			<do_if value="$harass_trader_ships">
+				<append_to_list name="$targetpurposes" exact="purpose.trade" />
+			</do_if>
+			<do_if value="$harass_miner_ships">
+				<append_to_list name="$targetpurposes" exact="purpose.mine" />
+			</do_if>
+
+			<!-- Required for all infinite orders, no effect in case of finite timeout -->
+			<set_order_syncpoint_reached order="this.ship.order" />
+
+			<!-- Main loop -->
+			<do_while value="$targetzone.exists">
+				<!-- Initial random position in zone -->
+				<get_safe_pos result="$pos" zone="$targetzone" radius="this.ship.size/2f" max="$radius" value="$zoneposition" />
+				<debug_to_file name="'BetterPiracy'" text="'%s --- betterpiracy.order.fight.corsair --- %s (%s) searching targets.'.[player.age, this.assignedcontrolled.knownname, this.assignedcontrolled.idcode]" />
+
+				<move_to object="this.ship" destination="$targetzone" finishonapproach="false" uselocalhighways="false" forceposition="false" forcesteering="false" travel="true">
+					<!--<position value="$targetpos" object="$destination"/>-->
+					<position value="$pos" />
+					<interrupt>
+						<conditions>
+							<!-- Found enemy that matches the filters in gravidar-->
+							<check_all>
+								<event_gravidar_has_scanned object="this.ship" />
+								<check_value value="not this.zone.isclass.highway" />
+								<check_value value="this.sector" comment="should already be covered by condition above, but just to be safe." />
+								<count_gravidar_contacts result="$detected" class="class.ship" docked="false" object="this.ship" functional="true" capturable="true" min="1">
+									<match_context macro="this.sector.macro" />
+									<match class="$targetclasses" />
+									<match_distance object="this.ship" max="$radius" />
+									<match_relation_of faction="this.trueowner" comparison="lt" relation="neutral" />
+									<match trueowner="[this.trueowner, faction.ownerless]" negate="true" />
+								</count_gravidar_contacts>
+								<check_any exact="$detected.count" counter="$i">
+									<check_value value="$targetpurposes.indexof.{@$detected.{$i}.primarypurpose}" />
+								</check_any>
+							</check_all>
+						</conditions>
+						<actions>
+							<set_value name="$target" exact="$detected.{1}" />
+						</actions>
+					</interrupt>
+				</move_to>
+
+				<do_if value="@$target.isoperational and @$target.iscapturable">
+					<!-- Pass signal through player to reach the MD file "betterpiracy_harass.xml", listened in cue "Harass_OperationCreated" -->
+					<debug_to_file name="'BetterPiracy'" text="'%s --- betterpiracy.order.fight.corsair --- %s (%s) found a target: %s (%s).'.[player.age, this.assignedcontrolled.knownname, this.assignedcontrolled.idcode, $target.knownname, $target.knownname]" />
+					<signal_objects object="player.entity" param="'corsair_init_harass'" param2="this.ship" param3="$target" />
+					<remove_value name="$target"/>
+				</do_if>
+
+				<!-- Resupply check, just in case -->
+				<do_if value="player.age gt @$next_resupply_check" chance="30">
+					<debug_to_file name="'BetterPiracy'" text="'%1 (%2) ready to resupply.'.[this.ship.knownname, this.ship]" />
+					<signal_objects object="this.ship" param="'resupply'" param2="[false]" comment="param2 = [urgent?, resupplystationID]" />
+					<set_value name="$next_resupply_check" exact="player.age + 30min" />
+				</do_if>
+
+				<wait exact="500ms" />
+			</do_while>
+		</actions>
+	</attention>
+	<on_abort>
+		<cease_fire object="this.ship" />
+		<debug_to_file name="'BetterPiracy'" text="'%s --- betterpiracy.order.fight.corsair --- %s (%s) aborting Corsair.'.[player.age, this.assignedcontrolled.knownname, this.assignedcontrolled.idcode]" />
+	</on_abort>
+</aiscript>

--- a/aiscripts/move.flee.dock.xml
+++ b/aiscripts/move.flee.dock.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<diff>
+	<!-- Only allied station will be selected -->
+	<!-- This selector matches lines 31 -->
+	<replace sel="//find_station">
+		<find_station name="$stations" functional="true" space="this.zone" multiple="true" >
+			<match_relation_to object="this" relation="neutral" comparison="ge" />
+			<match_relation_to object="$attacker" relation="neutral" comparison="le" />
+		</find_station>
+	</replace>
+</diff>

--- a/content.xml
+++ b/content.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<content id="ws_2056100433" name="Better piracy" description="X4 Foundations mod to improve piracy." version="1000" save="0" author="alberto-rota" date="2020-05-10" sync="false" lastupdate="1589100419">
+<content id="ws_2056100433" name="Better piracy" description="X4 Foundations mod to improve piracy." version="1100" save="0" author="alberto-rota" date="2020-05-16" sync="false" lastupdate="1589601749">
   <langugage language="7" description="X4 Foundations mod to improve piracy."/>
   <langugage language="33" description="X4 Foundations mod to improve piracy."/>
   <langugage language="34" description="Mod para X4 Foundations que mejora la piratería."/>

--- a/libraries/icons.xml
+++ b/libraries/icons.xml
@@ -2,4 +2,5 @@
 <!DOCTYPE icons SYSTEM "icons.dtd" >
 <icons>
     <icon name="order_harass" texture="assets\fx\gui\textures\order\order_board.tga" height="32" width="32"></icon>
+    <icon name="order_corsair" texture="assets\fx\gui\textures\order\order_board.tga" height="32" width="32"></icon>
 </icons>

--- a/md/betterpiracy_custom_bail_logic.xml
+++ b/md/betterpiracy_custom_bail_logic.xml
@@ -22,8 +22,8 @@
       <set_value name="$Config"                 exact="md.Betterpiracy_config.Config.$Config"/>
 
       <set_value name="$targetEffectiveMorale"  exact="[$target.pilot.skill.morale - ($MissionCue.$Pressure * $Config.{'$pressure_buildup_rate'})i, 0].max"/>
-      <set_value name="$attacker"               exact="player.occupiedship"/>
-      <set_value name="$isPlayerInvolved"       exact="player.sector.knownname == $target.sector.knownname"/>
+      <set_value name="$attacker"               exact="$MissionCue.$MainHarasser"/>
+      <set_value name="$isPlayerInvolved"       exact="$MissionCue.$MainHarasser == player.ship"/>
       
       <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_custom_bail_logic  --- %s (%s) triggered bail check on %s (%s).'.[player.age, $attacker.knownname, $attacker.idcode, $target.knownname, $target.idcode]" />
 
@@ -114,7 +114,8 @@
 
             <!-- Reputation hit for doing piracy -->
             <do_if value="$Config.{'$harass_reputation_hit'} == 1">
-              <signal_cue_instantly cue="PlayerBoarding" param="[$target, 'boarding started']" />
+              <!-- Reputation hit disabled until I find a proper way of handling it. -->
+              <!-- <signal_cue_instantly cue="PlayerBoarding" param="[$target, 'boarding started']" /> -->
             </do_if>
             
             <!-- Clear all target orders and empty it -->
@@ -145,7 +146,7 @@
             </do_if>
 
             <!-- If the ship is still alive, destroy some of their componets (Shields excluded to keep compatibility with VRO)-->
-            <do_if value="$Config.{'$harass_bailing_pilots_damage_components'} == 1">
+            <do_if value="$Config.{'$harass_bailing_pilots_destroy_components'} == 1">
               <do_if value="$target.exists">
                 <add_effect object="$target" effect="$target.scuttleeffect"/>
                 <find_object_component name="$subcomponents" object="$target" class="[class.weapon, class.turret]" multiple="true"/>

--- a/md/betterpiracy_harass.xml
+++ b/md/betterpiracy_harass.xml
@@ -20,18 +20,33 @@
           $disabled_conditions = ['~show_PlayerInteractions', '~is_playerowned'],
           ]"
       />
-      <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass            --- Registered custom `Harass` command as:  %s.'.[player.age, {61537, 5100}]" />
+      <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass --- Registered custom `Harass` command as:  %s.'.[player.age, {61537, 5100}]" />
     </actions>
   </cue>
 
   <!-- Root cue where the state of the operation will be stored -->
   <cue name="Harass_OperationCreated" instantiate="true" namespace="this">
     <conditions>
-      <event_cue_signalled/>
+      <check_any>
+        <event_cue_signalled/>
+        <event_object_signalled object="player.entity" param="'corsair_init_harass'" />
+      </check_any>
     </conditions>
     <actions>
       <set_value name="$MissionCue"   exact="Harass_OperationCreated"/>
-      <set_value name="$Target"       exact="event.param.$object"/>
+
+      <do_if value="event.param == 'corsair_init_harass'">
+        <set_value name="$MainHarasser" exact="event.param2"/>
+        <set_value name="$Target"       exact="event.param3"/>
+        <set_value name="$HasMission"   exact="false"/>
+      </do_if>
+      <do_else>
+        <set_value name="$MainHarasser" exact="player.ship"/>
+        <set_value name="$Target"       exact="event.param.$object"/>
+        <set_value name="$HasMission"   exact="true"/>
+      </do_else>
+      
+      
       <set_value name="$Config"       exact="md.Betterpiracy_config.Config.$Config"/>
       <set_value name="$CurrentPhase" exact="'Harass_OperationCreated'"/>
       <set_value name="$Pressure"     exact="0"/>
@@ -50,13 +65,13 @@
       <set_value name="$MissionStep_WaitBailing"   exact="4"/>
       <set_value name="$MissionStep_ClaimShip"     exact="5"/>
 
-      <set_value name="$Harassers" exact="player.ship.subordinates" />
-      <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass            --- Harass operation created: $MissionCue = %s, $Target = %s (%s), $MaxDistance = %s.'.[player.age, $MissionCue, $Target.knownname, $Target.idcode, $MaxDistance]" />
+      <set_value name="$Harassers" exact="$MainHarasser.subordinates" />
+      <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass --- Harass operation created: $MissionCue = %s, $MainHarasser = %s (%s), $Target = %s (%s), $MaxDistance = %s.'.[player.age, $MissionCue, $MainHarasser.knownname, $MainHarasser.idcode, $Target.knownname, $Target.idcode, $MaxDistance]" />
     </actions>
     <cues>
       <cue name="Harass_Init">
         <actions>
-          <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass            --- %s calling `Harass_Init` cue.'.[player.age, $MissionCue]" />
+          <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass --- %s calling `Harass_Init` cue.'.[player.age, $MissionCue]" />
           <signal_cue_instantly cue="Harass_ChangePhase" param="'createMission'"/>
         </actions>
       </cue>
@@ -65,7 +80,7 @@
           <event_mission_aborted cue="$MissionCue"/>
         </conditions>
         <actions>
-          <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass            --- %s calling `Harass_Aborted` cue.'.[player.age, $MissionCue]" />
+          <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass --- %s calling `Harass_Aborted` cue.'.[player.age, $MissionCue]" />
           <signal_cue_instantly cue="Harass_ChangePhase" param="'finish'"/>
         </actions>
       </cue>
@@ -73,36 +88,40 @@
       <!-- Library - INIT -->
       <library name="Harass_CheckTarget">
         <actions>
-          <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass            --- %s calling `Harass_CheckTarget` library: $Target.isoperational = %s, $Target.owner = %s'.[player.age, $MissionCue, $Target.isoperational, $Target.owner]" />
-          <do_if value="not $Target.isoperational">
+          <do_if value="not $Target.isoperational or $Target.dock or not $MainHarasser.isoperational or $MainHarasser.sector != $Target.sector">
+            <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass --- %s `Harass_CheckTarget` library check failed, operation can not continue: $Target.isoperational = %s, $Target.dock = %s, $MainHarasser.isoperational = %s, $MainHarasser.sector = %s, $Target.sector = %s'.[player.age, $MissionCue, $Target.isoperational, $Target.dock, $MainHarasser.isoperational, $MainHarasser.sector, $Target.sector]" />
             <signal_cue_instantly cue="Harass_ChangePhase" param="'finish'"/>
           </do_if>
           <do_if value="$Target.owner == faction.ownerless">
+            <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass --- %s `Harass_CheckTarget` library check passed, moving to claim phase: $Target.owner = %s'.[player.age, $MissionCue, $Target.owner]" />
             <signal_cue_instantly cue="Harass_ChangePhase" param="'claim'"/>
           </do_if>
           <do_if value="$Target.owner == faction.player">
+            <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass --- %s `Harass_CheckTarget` library check passed, moving to finish phase: $Target.owner = %s'.[player.age, $MissionCue, $Target.owner]" />
             <signal_cue_instantly cue="Harass_ChangePhase" param="'finish'"/>
           </do_if>
         </actions>
       </library>
       <library name="Harass_CheckShields">
         <actions>
-          <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass            --- %s calling `Harass_CheckShields` library: $Target.shieldpercentage = %s, $Config.{`$harass_shield_threshold`} = %s'.[player.age, $MissionCue, $Target.shieldpercentage, $Config.{'$harass_shield_threshold'}]" />
           <do_if value="$Target.shieldpercentage ge $Config.{'$harass_shield_threshold'}">
+            <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass --- %s `Harass_CheckShields` library check failed, rolling back to damageShields phase: $Target.shieldpercentage = %s, $Config.{`$harass_shield_threshold`} = %s'.[player.age, $MissionCue, $Target.shieldpercentage, $Config.{'$harass_shield_threshold'}]" />
             <signal_cue_instantly cue="Harass_ChangePhase" param="'damageShields'"/>
           </do_if>
         </actions>
       </library>
       <library name="Harass_CheckHull">
         <actions>
-          <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass            --- %s calling `Harass_CheckHull` library: $Target.hullpercentage = %s, $BailAttepmps = %s, $Config.{`$harass_bail_attepmps_before_mid`} = %s, $Config.{`$harass_bail_attepmps_before_late`} = %s, $Config.{`$early_harass_hull_threshold`} = %s, $Config.{`$mid_harass_hull_threshold`} = %s, $Config.{`$late_harass_hull_threshold`} = %s'.[player.age, $MissionCue, $Target.hullpercentage, $BailAttepmps, $Config.{'$harass_bail_attepmps_before_mid'}, $Config.{'$harass_bail_attepmps_before_late'}, $Config.{'$early_harass_hull_threshold'}, $Config.{'$mid_harass_hull_threshold'}, $Config.{'$late_harass_hull_threshold'}]" />
           <do_if value="$BailAttepmps ge $Config.{'$harass_bail_attepmps_before_late'} and $Target.hullpercentage ge $Config.{'$late_harass_hull_threshold'}">
+            <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass --- %s `Harass_CheckHull` library check failed, rolling back to damageHull phase: $Target.hullpercentage = %s, $BailAttepmps = %s, $Config.{`$harass_bail_attepmps_before_mid`} = %s, $Config.{`$harass_bail_attepmps_before_late`} = %s, $Config.{`$early_harass_hull_threshold`} = %s, $Config.{`$mid_harass_hull_threshold`} = %s, $Config.{`$late_harass_hull_threshold`} = %s'.[player.age, $MissionCue, $Target.hullpercentage, $BailAttepmps, $Config.{'$harass_bail_attepmps_before_mid'}, $Config.{'$harass_bail_attepmps_before_late'}, $Config.{'$early_harass_hull_threshold'}, $Config.{'$mid_harass_hull_threshold'}, $Config.{'$late_harass_hull_threshold'}]" />
             <signal_cue_instantly cue="Harass_ChangePhase" param="'damageHull'"/>
           </do_if>
           <do_elseif value="$BailAttepmps ge $Config.{'$harass_bail_attepmps_before_mid'} and $Target.hullpercentage ge $Config.{'$mid_harass_hull_threshold'}">
+            <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass --- %s `Harass_CheckHull` library check failed, rolling back to damageHull phase: $Target.hullpercentage = %s, $BailAttepmps = %s, $Config.{`$harass_bail_attepmps_before_mid`} = %s, $Config.{`$harass_bail_attepmps_before_late`} = %s, $Config.{`$early_harass_hull_threshold`} = %s, $Config.{`$mid_harass_hull_threshold`} = %s, $Config.{`$late_harass_hull_threshold`} = %s'.[player.age, $MissionCue, $Target.hullpercentage, $BailAttepmps, $Config.{'$harass_bail_attepmps_before_mid'}, $Config.{'$harass_bail_attepmps_before_late'}, $Config.{'$early_harass_hull_threshold'}, $Config.{'$mid_harass_hull_threshold'}, $Config.{'$late_harass_hull_threshold'}]" />
             <signal_cue_instantly cue="Harass_ChangePhase" param="'damageHull'"/>
           </do_elseif>
           <do_elseif value="$Target.hullpercentage ge $Config.{'$early_harass_hull_threshold'}">
+            <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass --- %s `Harass_CheckHull` library check failed, rolling back to damageHull phase: $Target.hullpercentage = %s, $BailAttepmps = %s, $Config.{`$harass_bail_attepmps_before_mid`} = %s, $Config.{`$harass_bail_attepmps_before_late`} = %s, $Config.{`$early_harass_hull_threshold`} = %s, $Config.{`$mid_harass_hull_threshold`} = %s, $Config.{`$late_harass_hull_threshold`} = %s'.[player.age, $MissionCue, $Target.hullpercentage, $BailAttepmps, $Config.{'$harass_bail_attepmps_before_mid'}, $Config.{'$harass_bail_attepmps_before_late'}, $Config.{'$early_harass_hull_threshold'}, $Config.{'$mid_harass_hull_threshold'}, $Config.{'$late_harass_hull_threshold'}]" />
             <signal_cue_instantly cue="Harass_ChangePhase" param="'damageHull'"/>
           </do_elseif>
         </actions>
@@ -121,16 +140,16 @@
             </do_if>
           </do_all>
 
-          <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass            --- %s calling `Harass_CheckDistance` library: $HarassersInRange = %s'.[player.age, $MissionCue, $HarassersInRange]" />
           <do_if value="$HarassersInRange == 0">
+            <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass --- %s calling `Harass_CheckDistance` library check failed, rolling back to chaseTarget phase: $HarassersInRange = %s'.[player.age, $MissionCue, $HarassersInRange]" />
             <signal_cue_instantly cue="Harass_ChangePhase" param="'chaseTarget'"/>
           </do_if>
         </actions>
       </library>
       <library name="Harass_CheckCrew">
         <actions>
-          <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass            --- %s calling `Harass_CheckCrew` library: $Target.iscapitalship = %s'.[player.age, $MissionCue, $Target.iscapitalship]" />
           <do_if value="$Target.iscapitalship and $Target.people.count le ($Target.people.capacity * ($Config.{'$harass_lxl_min_crew_left_base'} + ($Config.{'$harass_lxl_min_crew_left_pilot'} * ((15 - $Target.pilot.skill.morale)f / 15.0))) / 100)i">
+            <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass --- %s calling `Harass_CheckCrew` library check passed, moving to claim phase: $Target.iscapitalship = %s'.[player.age, $MissionCue, $Target.iscapitalship]" />
             <signal_cue_instantly cue="Harass_ChangePhase" param="'claim'"/>
           </do_if>
         </actions>
@@ -146,7 +165,7 @@
           <do_if value="$CurrentPhase">
             <set_value name="$TargetPhase" exact="event.param"/>
 
-            <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass            --- %s changing phase from `%s` to `%s`.'.[player.age, $MissionCue, $CurrentPhase, $TargetPhase]" />
+            <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass --- %s changing phase from `%s` to `%s`.'.[player.age, $MissionCue, $CurrentPhase, $TargetPhase]" />
           
             <do_if value="$CurrentPhase != 'Harass_OperationCreated'">
               <cancel_cue cue="$CurrentPhase"/>
@@ -176,7 +195,7 @@
             </do_elseif>
           </do_if>
           <do_else>
-            <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass            --- %s changing phase to `%s` skipped.'.[player.age, $MissionCue, $TargetPhase]" />
+            <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass --- %s changing phase to `%s` skipped.'.[player.age, $MissionCue, $TargetPhase]" />
           </do_else>
         </actions>
       </cue>
@@ -188,16 +207,24 @@
         <actions>
           <set_value name="$CurrentPhase" exact="this"/>
 
-          <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass            --- %s calling `Harass_CreateMission` cue.'.[player.age, $MissionCue]" />
-          <create_mission cue="$MissionCue" name="{61537, 5101}" description="{61537, 5102}" faction="faction.player" type="missiontype.fight">
-            <briefing>
-              <objective step="$MissionStep_DamageShields"  action="objective.custom"   customaction="{61537, 5103}"  text="{61537, 5105}" comment="'Increase pressure: Destroy their shields'"/>
-              <objective step="$MissionStep_DamageHull"     action="objective.custom"   customaction="{61537, 5103}"  text="{61537, 5106}" comment="'Increase pressure: Damage their hull'"/>
-              <objective step="$MissionStep_ChaseTarget"    action="objective.approach"                               text="{61537, 5107}" comment="'Approach: Get closer to your target'"/>
-              <objective step="$MissionStep_WaitBailing"    action="objective.custom"   customaction="{61537, 5104}"  text="{61537, 5108}" comment="'Maintain pressure: Do not kill the target!'"/>
-              <objective step="$MissionStep_ClaimShip"      action="objective.claim"                                  text="{61537, 5109}" comment="'Claim: The ship is empty'"/>
-            </briefing>
-          </create_mission>
+          <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass --- %s calling `Harass_CreateMission` cue.'.[player.age, $MissionCue]" />
+          <do_if value="$HasMission">
+            <create_mission cue="$MissionCue" name="{61537, 5101}" description="{61537, 5102}" faction="faction.player" type="missiontype.fight">
+              <briefing>
+                <objective step="$MissionStep_DamageShields"  action="objective.custom"   customaction="{61537, 5103}"  text="{61537, 5105}" comment="'Increase pressure: Destroy their shields'"/>
+                <objective step="$MissionStep_DamageHull"     action="objective.custom"   customaction="{61537, 5103}"  text="{61537, 5106}" comment="'Increase pressure: Damage their hull'"/>
+                <objective step="$MissionStep_ChaseTarget"    action="objective.approach"                               text="{61537, 5107}" comment="'Approach: Get closer to your target'"/>
+                <objective step="$MissionStep_WaitBailing"    action="objective.custom"   customaction="{61537, 5104}"  text="{61537, 5108}" comment="'Maintain pressure: Do not kill the target!'"/>
+                <objective step="$MissionStep_ClaimShip"      action="objective.claim"                                  text="{61537, 5109}" comment="'Claim: The ship is empty'"/>
+              </briefing>
+            </create_mission>
+          </do_if>
+          <do_else>
+            <create_order id="'Harass'" object="$MainHarasser">
+              <param name="target" value="$Target"/>
+              <param name="harassoperation" value="$MissionCue"/>
+            </create_order>
+          </do_else>
 
           <do_all exact="$Harassers.count" counter="$i">
             <create_order id="'Harass'" object="$Harassers.{$i}">
@@ -216,24 +243,24 @@
         </conditions>
         <actions>
           <set_value name="$CurrentPhase" exact="this"/>
-          <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass            --- %s calling `Harass_DamageShields` cue.'.[player.age, $MissionCue]" />
+          <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass --- %s calling `Harass_DamageShields` cue.'.[player.age, $MissionCue]" />
+          <signal_objects object="$Target" param="$MissionCue" param2="'harass__attack'"/>
         </actions>
         <cues>
           <cue name="Harass_DamageShields_Check" instantiate="true" checkinterval="1s">
             <actions>
               <include_actions ref="Harass_CheckTarget"/>
 
-              <signal_objects object="$Target" param="$MissionCue" param2="'harass__attack'"/>
-
               <do_if value="$Target.shieldpercentage le ($Config.{'$harass_shield_threshold'} - 10)">
-                <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass            --- %s --- `Harass_DamageShields_Check` passed: $Target.shieldpercentage = %s, $Config.{`$harass_shield_threshold`} = %s.'.[player.age, $MissionCue, $Target.shieldpercentage, $Config.{'$harass_shield_threshold'}]" />
+                <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass --- %s --- `Harass_DamageShields_Check` passed, moving to damageHull phase: $Target.shieldpercentage = %s, $Config.{`$harass_shield_threshold`} = %s.'.[player.age, $MissionCue, $Target.shieldpercentage, $Config.{'$harass_shield_threshold'}]" />
                 <signal_cue_instantly cue="Harass_ChangePhase" param="'damageHull'"/>
               </do_if>
               <do_else>
-                <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass            --- %s --- `Harass_DamageShields_Check` updated: $Target.shieldpercentage = %s, $Config.{`$harass_shield_threshold`} = %s.'.[player.age, $MissionCue, $Target.shieldpercentage, $Config.{'$harass_shield_threshold'}]" />
-                <set_objective cue="$MissionCue" step="$MissionStep_DamageShields" action="objective.custom" customaction="{61537, 5103}" text="{61537, 5105}" object="$Target" silent="true">
-                  <progress progress="100 - $Target.shieldpercentage" max="100 - ($Config.{'$harass_shield_threshold'} - 10)"/>
-                </set_objective>
+                <do_if value="$HasMission">
+                  <set_objective cue="$MissionCue" step="$MissionStep_DamageShields" action="objective.custom" customaction="{61537, 5103}" text="{61537, 5105}" object="$Target" silent="true">
+                    <progress progress="100 - $Target.shieldpercentage" max="100 - ($Config.{'$harass_shield_threshold'} - 10)"/>
+                  </set_objective>
+                </do_if>
               </do_else>
             </actions>
           </cue>
@@ -246,15 +273,14 @@
         </conditions>
         <actions>
           <set_value name="$CurrentPhase" exact="this"/>
-          <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass            --- %s calling `Harass_DamageHull` cue.'.[player.age, $MissionCue]" />
+          <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass --- %s calling `Harass_DamageHull` cue.'.[player.age, $MissionCue]" />
+          <signal_objects object="$Target" param="$MissionCue" param2="'harass__attack'"/>
         </actions>
         <cues>
           <cue name="Harass_DamageHull_Check" instantiate="true" checkinterval="1s">
             <actions>
               <include_actions ref="Harass_CheckTarget"/>
               <include_actions ref="Harass_CheckShields"/>
-
-              <signal_objects object="$Target" param="$MissionCue" param2="'harass__attack'"/>
     
               <do_if value="$BailAttepmps ge $Config.{'$harass_bail_attepmps_before_late'}">
                 <set_value name="$MissedHullThreshold" exact="100 - $Config.{'$late_harass_hull_threshold'}"/>
@@ -268,14 +294,15 @@
 
               <set_value name="$TargetHullMissed" exact="100 - $Target.hullpercentage"/>
               <do_if value="$TargetHullMissed ge $MissedHullThreshold">
-                <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass            --- %s --- `Harass_DamageHull_Check` passed: $Target.hullpercentage = %s, $TargetHullMissed = %s.'.[player.age, $MissionCue, $Target.hullpercentage, $TargetHullMissed]" />
+                <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass --- %s --- `Harass_DamageHull_Check` passed, moving to chaseTarget phase: $Target.hullpercentage = %s, $TargetHullMissed = %s.'.[player.age, $MissionCue, $Target.hullpercentage, $TargetHullMissed]" />
                 <signal_cue_instantly cue="Harass_ChangePhase" param="'chaseTarget'"/>
               </do_if>
               <do_else>
-                <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass            --- %s --- `Harass_DamageHull_Check` updated: $Target.hullpercentage = %s, $TargetHullMissed = %s.'.[player.age, $MissionCue, $Target.hullpercentage, $TargetHullMissed]" />
-                <set_objective cue="$MissionCue" step="$MissionStep_DamageHull" action="objective.custom" customaction="{61537, 5103}" text="{61537, 5106}" object="$Target" silent="true">
-                  <progress progress="$TargetHullMissed" max="$MissedHullThreshold"/>
-                </set_objective>
+                <do_if value="$HasMission">
+                  <set_objective cue="$MissionCue" step="$MissionStep_DamageHull" action="objective.custom" customaction="{61537, 5103}" text="{61537, 5106}" object="$Target" silent="true">
+                    <progress progress="$TargetHullMissed" max="$MissedHullThreshold"/>
+                  </set_objective>
+                </do_if>
               </do_else>
             </actions>
           </cue>
@@ -288,8 +315,11 @@
         </conditions>
         <actions>
           <set_value name="$CurrentPhase" exact="this"/>
-          <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass            --- %s calling `Harass_ChaseTarget` cue.'.[player.age, $MissionCue]" />
-          <set_objective cue="$MissionCue" step="$MissionStep_ChaseTarget" action="objective.approach" text="{61537, 5107}" object="$Target" silent="true"/>
+          <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass --- %s calling `Harass_ChaseTarget` cue.'.[player.age, $MissionCue]" />
+          <signal_objects object="$Target" param="$MissionCue" param2="'harass__chase'"/>
+          <do_if value="$HasMission">
+            <set_objective cue="$MissionCue" step="$MissionStep_ChaseTarget" action="objective.approach" text="{61537, 5107}" object="$Target" silent="true"/>
+          </do_if>
         </actions>
         <cues>
           <cue name="Harass_ChaseTarget_Check" instantiate="true" checkinterval="1s">
@@ -298,7 +328,6 @@
               <include_actions ref="Harass_CheckShields"/>
               <include_actions ref="Harass_CheckHull"/>
 
-              <signal_objects object="$Target" param="$MissionCue" param2="'harass__chase'"/>
               <set_value name="$HarassersInRange" exact="0"/>
               <!-- Check if player is close to target -->
               <do_if value="player.entity.distanceto.{$Target} le $MaxDistance">
@@ -311,7 +340,7 @@
                 </do_if>
               </do_all>
               <do_if value="$HarassersInRange gt 0">
-                <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass            --- %s --- `Harass_ChaseTarget_Check` passed: $HarassersInRange = %s.'.[player.age, $MissionCue, $HarassersInRange]" />
+                <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass --- %s --- `Harass_ChaseTarget_Check` passed, moving to waitSurrender phase: $HarassersInRange = %s.'.[player.age, $MissionCue, $HarassersInRange]" />
                 <signal_cue_instantly cue="Harass_ChangePhase" param="'waitSurrender'"/>
               </do_if>
             </actions>
@@ -325,8 +354,8 @@
         </conditions>
         <actions>
           <set_value name="$CurrentPhase" exact="this"/>
-          <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass            --- %s calling `Harass_WaitForSurrender` cue.'.[player.age, $MissionCue]" />
-          
+          <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass --- %s calling `Harass_WaitForSurrender` cue.'.[player.age, $MissionCue]" />
+          <signal_objects object="$Target" param="$MissionCue" param2="'harass__chase'"/>
           <set_value name="$NextBailCheck" exact="player.age + ($Config.{'$keep_pressure_timer'})s"/>
           <set_value name="$InitialTimeLeft" exact="$NextBailCheck - player.age"/>
         </actions>
@@ -338,21 +367,22 @@
               <include_actions ref="Harass_CheckShields"/>
               <include_actions ref="Harass_CheckHull"/>
               <include_actions ref="Harass_CheckDistance"/>
-    
-              <signal_objects object="$Target" param="$MissionCue" param2="'harass__chase'"/>
 
               <set_value name="$CurrentTimeLeft" exact="$NextBailCheck - player.age"/>
-              <set_objective cue="$MissionCue" step="$MissionStep_WaitBailing" action="objective.custom" customaction="{61537, 5104}" text="{61537, 5108}" object="$Target" silent="true">
-                <progress progress="$InitialTimeLeft - $CurrentTimeLeft" max="$InitialTimeLeft"/>
-              </set_objective>
+              <do_if value="$HasMission">
+                <set_objective cue="$MissionCue" step="$MissionStep_WaitBailing" action="objective.custom" customaction="{61537, 5104}" text="{61537, 5108}" object="$Target" silent="true">
+                  <progress progress="$InitialTimeLeft - $CurrentTimeLeft" max="$InitialTimeLeft"/>
+                </set_objective>
+              </do_if>
               
               <do_if value="$CurrentTimeLeft le 0">
                 <set_value name="$NextBailCheck" exact="player.age + ($Config.{'$keep_pressure_timer'})s"/>
                 <set_value name="$Pressure" operation="add"/>
                 <set_value name="$BailAttepmps" operation="add"/>
-                <speak actor="player.computer" page="61538" line="[4401, 4402, 4403, 4404, 4405, 4406, 4407, 4408, 4409].random" priority="90"/>
-                
-                <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass            --- %s --- `Harass_WaitForSurrender_Check` passed: $NextBailCheck = %s, $Pressure = %s, $BailAttepmps = %s.'.[player.age, $MissionCue, $NextBailCheck, $Pressure, $BailAttepmps]" />
+                <do_if value="$HasMission">
+                  <speak actor="player.computer" page="61538" line="[4401, 4402, 4403, 4404, 4405, 4406, 4407, 4408, 4409].random" priority="90"/>
+                </do_if>
+                <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass --- %s --- `Harass_WaitForSurrender_Check` passed, triggering bail attemp: $NextBailCheck = %s, $Pressure = %s, $BailAttepmps = %s.'.[player.age, $MissionCue, $NextBailCheck, $Pressure, $BailAttepmps]" />
                 <signal_cue_instantly cue="md.Betterpiracy_custom_bail_logic.PlayerOwnedShipHarass" param="$MissionCue"/>
               </do_if>
             </actions>
@@ -366,15 +396,18 @@
         </conditions>
         <actions>
           <set_value name="$CurrentPhase" exact="this"/>
-          <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass            --- %s calling `Harass_Claim` cue.'.[player.age, $MissionCue]" />
-
+          <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass --- %s calling `Harass_Claim` cue.'.[player.age, $MissionCue]" />
           <signal_objects object="$Target" param="$MissionCue" param2="'harass__end'"/>
-
-          <do_if value="$Target.iscapitalship">
-            <set_objective cue="$MissionCue" step="$MissionStep_ClaimShip" action="objective.board" text="{61537, 5110}" object="$Target" silent="true"/>
+          <do_if value="$HasMission">
+            <do_if value="$Target.iscapitalship">
+              <set_objective cue="$MissionCue" step="$MissionStep_ClaimShip" action="objective.board" text="{61537, 5110}" object="$Target" silent="true"/>
+            </do_if>
+            <do_else>
+              <set_objective cue="$MissionCue" step="$MissionStep_ClaimShip" action="objective.claim" text="{61537, 5109}" object="$Target" silent="true"/>
+            </do_else>
           </do_if>
           <do_else>
-            <set_objective cue="$MissionCue" step="$MissionStep_ClaimShip" action="objective.claim" text="{61537, 5109}" object="$Target" silent="true"/>
+            <signal_cue_instantly cue="Harass_ChangePhase" param="'finish'"/>
           </do_else>
         </actions>
         <cues>
@@ -393,10 +426,12 @@
           <event_cue_signalled/>
         </conditions>
         <actions>
-          <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass            --- %s calling `Harass_Finish` cue.'.[player.age, $MissionCue]" />
+          <debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass --- %s calling `Harass_Finish` cue.'.[player.age, $MissionCue]" />
 
           <signal_objects object="$Target" param="$MissionCue" param2="'harass__end'"/>
-          <remove_mission cue="$MissionCue" type="completed"/>
+          <do_if value="$HasMission">
+            <remove_mission cue="$MissionCue" type="completed"/>
+          </do_if>
           <cancel_cue cue="$MissionCue"/>
         </actions>
       </cue>

--- a/md/notifications.xml
+++ b/md/notifications.xml
@@ -25,8 +25,9 @@
 	<!-- This selector matches line 1012 -->
 	<add sel="//eject_npcs" pos="before">
 		<!-- Reputation hit for doing piracy -->
-		<do_if value="md.Betterpiracy_config.Config.$Config.{'$harass_reputation_hit'} == 1">
-			<signal_cue_instantly cue="PlayerBoarding" param="[$target, 'boarding started']" />
+		<do_if value="md.Betterpiracy_config.Config.$Config.{'$combat_reputation_hit'} == 1">
+			<!-- Reputation hit disabled until I find a proper way of handling it. -->
+			<!-- <signal_cue_instantly cue="PlayerBoarding" param="[$target, 'boarding started']" /> -->
 		</do_if>
 
 		<!-- Remove extra damage to hull -->

--- a/t/0001-l033.xml
+++ b/t/0001-l033.xml
@@ -5,6 +5,13 @@
     <!-- Harass order related texts -->
     <t id="5050">Harass</t>
     <t id="5051">Directly harass a target or support a harass operation.</t>
+    <t id="5052">Corsair</t>
+    <t id="5053">Command a pirate gang to harass ships in sector.</t>
+    <t id="5054">Target S sized ships: </t>
+    <t id="5055">Target M sized ships: </t>
+    <t id="5056">Target combat ships: </t>
+    <t id="5057">Target trader ships: </t>
+    <t id="5058">Target mining ships: </t>
     <!-- Harass mission related texts -->
     <t id="5100">Harceler</t>
     <t id="5101">(Harass mission title)Harcèlement </t>

--- a/t/0001-l034.xml
+++ b/t/0001-l034.xml
@@ -5,6 +5,13 @@
     <!-- Harass order related texts -->
     <t id="5050">Harass</t>
     <t id="5051">Directly harass a target or support a harass operation.</t>
+    <t id="5052">Corsair</t>
+    <t id="5053">Command a pirate gang to harass ships in sector.</t>
+    <t id="5054">Target S sized ships: </t>
+    <t id="5055">Target M sized ships: </t>
+    <t id="5056">Target combat ships: </t>
+    <t id="5057">Target trader ships: </t>
+    <t id="5058">Target mining ships: </t>
     <!-- Harass mission related texts -->
     <t id="5100">Acosar</t>
     <t id="5101">(Harass mission title)Operación de acoso </t>

--- a/t/0001-l044.xml
+++ b/t/0001-l044.xml
@@ -5,6 +5,13 @@
     <!-- Harass order related texts -->
     <t id="5050">Harass</t>
     <t id="5051">Directly harass a target or support a harass operation.</t>
+    <t id="5052">Corsair</t>
+    <t id="5053">Command a pirate gang to harass ships in sector.</t>
+    <t id="5054">Target S sized ships: </t>
+    <t id="5055">Target M sized ships: </t>
+    <t id="5056">Target combat ships: </t>
+    <t id="5057">Target trader ships: </t>
+    <t id="5058">Target mining ships: </t>
     <!-- Harass mission related texts -->
     <t id="5100">Harass</t>
     <t id="5101">(Harass mission title)Harass Operation </t>

--- a/t/0001-l049.xml
+++ b/t/0001-l049.xml
@@ -5,6 +5,13 @@
     <!-- Harass order related texts -->
     <t id="5050">Harass</t>
     <t id="5051">Directly harass a target or support a harass operation.</t>
+    <t id="5052">Corsair</t>
+    <t id="5053">Command a pirate gang to harass ships in sector.</t>
+    <t id="5054">Target S sized ships: </t>
+    <t id="5055">Target M sized ships: </t>
+    <t id="5056">Target combat ships: </t>
+    <t id="5057">Target trader ships: </t>
+    <t id="5058">Target mining ships: </t>
     <!-- Harass mission related texts -->
     <t id="5100">Schikanieren</t>
     <t id="5101">(Harass mission title)Gegnercrew schikanieren </t>

--- a/t/0001.xml
+++ b/t/0001.xml
@@ -5,6 +5,13 @@
     <!-- Harass order related texts -->
     <t id="5050">Harass</t>
     <t id="5051">Directly harass a target or support a harass operation.</t>
+    <t id="5052">Corsair</t>
+    <t id="5053">Command a pirate gang to harass ships in sector.</t>
+    <t id="5054">Target S sized ships: </t>
+    <t id="5055">Target M sized ships: </t>
+    <t id="5056">Target combat ships: </t>
+    <t id="5057">Target trader ships: </t>
+    <t id="5058">Target mining ships: </t>
     <!-- Harass mission related texts -->
     <t id="5100">Harass</t>
     <t id="5101">(Harass mission title)Harass Operation </t>


### PR DESCRIPTION
- Created new default order `Corsair`, ships/fleets with this behavior will smartly harass selected enemy targets
 - Improved Harass operation logic
 - Improved debug logging
 - Disabled `combat_reputation_hit` and `harass_reputation_hit`, I need to find a better way of handling it
 - Stations will not allow a fleeing ship to dock if the attacker is allied to them
 - Separated changes into `Major changes` and `Minor changes` to increase readability